### PR TITLE
Fix: PHP intl extension is now required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -y install build-essential gcc git osmosis  libxml2-dev libgeos-dev 
 RUN apt-get -y install autoconf make g++ libboost-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev lua5.2 liblua5.2-dev
 
 # Install PHP5
-RUN apt-get -y install php5 php-pear php5-pgsql php5-json php-db
+RUN apt-get -y install php5 php-pear php5-pgsql php5-json php-db php5-intl
 
 # From the website "If you plan to install the source from github, the following additional packages are needed:"
 # RUN apt-get -y install git autoconf-archive

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Stop the container
 docker stop nominatim_container
 ```
 
-Connect to the nominatim webserver with curl. If this succeeds, open [http://localhost:8080/](http:/localhost:8080) in a web browser
+Connect to the nominatim webserver with curl. If this succeeds, open [http://localhost:8080/search.php](http:/localhost:8080) in a web browser
 
 ```
-curl "http://localhost:8080"
+curl "http://localhost:8080/search.php"
 ```


### PR DESCRIPTION
Hi,

Nominatim search now need PHP5-intl to be install. just check this issue:
https://github.com/openstreetmap/Nominatim/issues/747

thks
